### PR TITLE
remove x-forwarded-for from all api spec and readme files

### DIFF
--- a/account-management/README.md
+++ b/account-management/README.md
@@ -96,11 +96,6 @@ The number of queries executed is controlled and limited by Logz.io.
                 "schema" : {
                   "$ref" : "#/definitions/TimeBasedAccountUpsertRequest"
                 }
-              }, {
-                "name" : "x-forwarded-for",
-                "in" : "header",
-                "required" : false,
-                "type" : "string"
               } ],
               "responses" : {
                 "200" : {
@@ -393,11 +388,6 @@ The number of queries executed is controlled and limited by Logz.io.
               "schema" : {
                 "$ref" : "#/definitions/TimeBasedAccountUpsertRequest"
               }
-            }, {
-              "name" : "x-forwarded-for",
-              "in" : "header",
-              "required" : false,
-              "type" : "string"
             } ],
             "responses" : {
               "default" : {
@@ -506,11 +496,6 @@ The number of queries executed is controlled and limited by Logz.io.
               "required" : true,
               "type" : "integer",
               "format" : "int32"
-            }, {
-              "name" : "x-forwarded-for",
-              "in" : "header",
-              "required" : false,
-              "type" : "string"
             } ],
             "responses" : {
               "default" : {

--- a/account-management/swagger.json
+++ b/account-management/swagger.json
@@ -35,11 +35,6 @@
           "schema" : {
             "$ref" : "#/definitions/TimeBasedAccountUpsertRequest"
           }
-        }, {
-          "name" : "x-forwarded-for",
-          "in" : "header",
-          "required" : false,
-          "type" : "string"
         } ],
         "responses" : {
           "200" : {
@@ -125,11 +120,6 @@
           "schema" : {
             "$ref" : "#/definitions/TimeBasedAccountUpsertRequest"
           }
-        }, {
-          "name" : "x-forwarded-for",
-          "in" : "header",
-          "required" : false,
-          "type" : "string"
         } ],
         "responses" : {
           "default" : {
@@ -146,11 +136,6 @@
           "required" : true,
           "type" : "integer",
           "format" : "int32"
-        }, {
-          "name" : "x-forwarded-for",
-          "in" : "header",
-          "required" : false,
-          "type" : "string"
         } ],
         "responses" : {
           "default" : {

--- a/endpoints/README.md
+++ b/endpoints/README.md
@@ -276,12 +276,6 @@ The number of queries executed is controlled and limited by Logz.io.
             ],
             "parameters": [
               {
-                "name": "x-forwarded-for",
-                "in": "header",
-                "required": false,
-                "type": "string"
-              },
-              {
                 "name": "id",
                 "in": "path",
                 "required": true,
@@ -364,12 +358,6 @@ The number of queries executed is controlled and limited by Logz.io.
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "name" : "test",
             "in" : "query",
@@ -488,12 +476,6 @@ The number of queries executed is controlled and limited by Logz.io.
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "name": "id",
             "in": "path",
@@ -619,12 +601,6 @@ The number of queries executed is controlled and limited by Logz.io.
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name" : "test",
             "in" : "query",
             "required" : false,
@@ -742,12 +718,6 @@ The number of queries executed is controlled and limited by Logz.io.
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "name": "id",
             "in": "path",
@@ -875,12 +845,6 @@ The number of queries executed is controlled and limited by Logz.io.
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name" : "test",
             "in" : "query",
             "required" : false,
@@ -1003,12 +967,6 @@ The number of queries executed is controlled and limited by Logz.io.
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "name": "id",
             "in": "path",
@@ -1138,12 +1096,6 @@ The number of queries executed is controlled and limited by Logz.io.
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name" : "test",
             "in" : "query",
             "required" : false,
@@ -1261,12 +1213,6 @@ The number of queries executed is controlled and limited by Logz.io.
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "name": "id",
             "in": "path",
@@ -1395,12 +1341,6 @@ The number of queries executed is controlled and limited by Logz.io.
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "name" : "test",
             "in" : "query",
@@ -1544,12 +1484,6 @@ The number of queries executed is controlled and limited by Logz.io.
             "format": "int32"
           },
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name" : "test",
             "in" : "query",
             "required" : false,
@@ -1687,12 +1621,6 @@ The number of queries executed is controlled and limited by Logz.io.
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "name" : "test",
             "in" : "query",
@@ -1833,12 +1761,6 @@ The number of queries executed is controlled and limited by Logz.io.
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "name": "id",
             "in": "path",

--- a/endpoints/swagger.json
+++ b/endpoints/swagger.json
@@ -21,12 +21,6 @@
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name": "id",
             "in": "path",
             "required": true,
@@ -82,12 +76,6 @@
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name" : "test",
             "in" : "query",
             "required" : false,
@@ -135,12 +123,6 @@
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "name": "id",
             "in": "path",
@@ -204,12 +186,6 @@
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name" : "test",
             "in" : "query",
             "required" : false,
@@ -258,12 +234,6 @@
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name" : "test",
             "in" : "query",
             "required" : false,
@@ -311,12 +281,6 @@
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "name": "id",
             "in": "path",
@@ -373,12 +337,6 @@
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name" : "test",
             "in" : "query",
             "required" : false,
@@ -426,12 +384,6 @@
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "name": "id",
             "in": "path",
@@ -488,12 +440,6 @@
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name" : "test",
             "in" : "query",
             "required" : false,
@@ -541,12 +487,6 @@
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "name": "id",
             "in": "path",
@@ -603,12 +543,6 @@
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name" : "test",
             "in" : "query",
             "required" : false,
@@ -662,12 +596,6 @@
             "required": true,
             "type": "integer",
             "format": "int32"
-          },
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
           },
           {
             "name" : "test",

--- a/user-management/README.md
+++ b/user-management/README.md
@@ -72,12 +72,6 @@ The number of queries executed is controlled and limited by Logz.io.
            ],
            "parameters": [
              {
-               "name": "x-forwarded-for",
-               "in": "header",
-               "required": false,
-               "type": "string"
-             },
-             {
                "name": "X-API-TOKEN",
                "in": "header",
                "description": "Authentication Api Token",
@@ -204,12 +198,6 @@ The number of queries executed is controlled and limited by Logz.io.
           ],
           "parameters": [
             {
-              "name": "x-forwarded-for",
-              "in": "header",
-              "required": false,
-              "type": "string"
-            },
-            {
               "in": "body",
               "name": "body",
               "required": false,
@@ -334,12 +322,6 @@ The number of queries executed is controlled and limited by Logz.io.
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name": "id",
             "in": "path",
             "required": true,
@@ -437,12 +419,6 @@ The number of queries executed is controlled and limited by Logz.io.
               "application/json"
             ],
             "parameters": [
-              {
-                "name": "x-forwarded-for",
-                "in": "header",
-                "required": false,
-                "type": "string"
-              },
               {
                 "in": "body",
                 "name": "body",
@@ -572,12 +548,6 @@ The number of queries executed is controlled and limited by Logz.io.
             ],
             "parameters": [
               {
-                "name": "x-forwarded-for",
-                "in": "header",
-                "required": false,
-                "type": "string"
-              },
-              {
                 "name": "id",
                 "in": "path",
                 "required": true,
@@ -655,12 +625,6 @@ The number of queries executed is controlled and limited by Logz.io.
              "application/json"
            ],
            "parameters": [
-             {
-               "name": "x-forwarded-for",
-               "in": "header",
-               "required": false,
-               "type": "string"
-             },
              {
                "name": "id",
                "in": "path",
@@ -741,12 +705,6 @@ The number of queries executed is controlled and limited by Logz.io.
              "application/json"
            ],
            "parameters": [
-             {
-               "name": "x-forwarded-for",
-               "in": "header",
-               "required": false,
-               "type": "string"
-             },
              {
                "name": "id",
                "in": "path",

--- a/user-management/swagger.json
+++ b/user-management/swagger.json
@@ -21,12 +21,6 @@
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name": "id",
             "in": "path",
             "required": true,
@@ -64,12 +58,6 @@
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "in": "body",
             "name": "body",
@@ -117,12 +105,6 @@
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name": "id",
             "in": "path",
             "required": true,
@@ -159,12 +141,6 @@
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "name": "id",
             "in": "path",
@@ -203,12 +179,6 @@
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name": "id",
             "in": "path",
             "required": true,
@@ -246,12 +216,6 @@
         ],
         "parameters": [
           {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name": "X-API-TOKEN",
             "in": "header",
             "description": "Authentication Api Token",
@@ -285,12 +249,6 @@
           "application/json"
         ],
         "parameters": [
-          {
-            "name": "x-forwarded-for",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
           {
             "in": "body",
             "name": "body",


### PR DESCRIPTION
shlomi advises that `x-forwarded-for` is no longer part of the api. i removed all `x-forwarded-for` instances from the public api spec.