### PR TITLE
Update README.md

### DIFF
--- a/scroll/README.md
+++ b/scroll/README.md
@@ -25,7 +25,7 @@ URL: https://api.logz.io/v1/scroll (US Accounts)
 
 ### Request Body 
 Elasticsearch Scroll API Body as documented  in [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-scroll.html), with the following restrictions:
-* We support the following top-level elements in the Elasticsearch Search API:  `query`, `from`, `size`, `sort`, `post_filter`, `scroll`, `scroll_id`.
+* We support the following top-level elements in the Elasticsearch Search API:  `query`, `size`, `sort`, `post_filter`, `scroll`, `scroll_id`.
 * When using the `query_string` element, you are not allowed to set its field named `allow_leading_wildcard` to true
 * When using the `wildcard` element, you are not allowed to have its value start with `*` or `?`
 * When using the `scroll_id` element, you are not allowed to use `query` element.


### PR DESCRIPTION
removed FROM as it seems to not be supported by scroll API, I tested the sroll api against ES directly and the "from" was not respected, also according to the docs below it says if you need more advanced drilling down use the scroll API so it implies that the "from" is not part of the scroll api

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html